### PR TITLE
Add RSS feed generation and OPML feed support

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation'
 export const siteTitle = 'WreckItRob';
-import Snowfall from 'react-snowfall'
+
 
 import { ReactNode } from 'react';
 
@@ -14,30 +14,65 @@ interface LayoutProps {
 export default function Layout({ children, home }: LayoutProps) {
   const pathname = usePathname()
   return (
-    <div lang='en'>
-      {pathname === '/christmas' && <Snowfall snowflakeCount={150}/>}
+    <div lang='en' className="flex flex-col min-h-screen">
       <Head>
-      <link rel="icon" href="/favicon.ico" />
-      <meta
-        name="description"
-        content="Robs personal site"
-      />
-      <meta name="og:title" content={siteTitle} />
-      <meta name="twitter:card" content="summary_large_image" />
+        <link rel="icon" href="/favicon.ico" />
+        <meta
+          name="description"
+          content="Robs personal site"
+        />
+        <meta name="og:title" content={siteTitle} />
+        <meta name="twitter:card" content="summary_large_image" />
       </Head>
       <header className="container mx-auto mt-4">
         <nav className='flex justify-between mt-4 lg:mt-16 px-4 lg:px-64 xl:px-64 mb-4 text-lg'>
-        <Link href="/" id='title' className='font-bold'>WreckItRob<span className='text-sky-400'>.</span>dev</Link>
-        <div className="flex flex-row items-center font-semibold">
-          <Link className={`nav-item ${pathname === '/' ? 'nav-active' : ''}`} href="/">
-          Home
-          </Link>
-          <Link className={`nav-item ${pathname === '/blog' ? 'nav-active' : ''}`} href="/blog">Blog</Link>
-          <Link className={`nav-item ${pathname === '/riddles' ? 'nav-active' : ''}`} href={`/riddles`}>Riddles</Link> 
-        </div>
-        </nav>
-      </header>
-      <main className="container mx-auto mt-32 lg:mt-32 px-4 lg:px-64 xl:px-64 mb-4">{children}</main>
+          <Link href="/" id='title' className='font-bold'>WreckItRob<span className='text-sky-400'>.</span>dev</Link>        <div className="flex flex-row items-center font-semibold">
+            <Link className={`nav-item ${pathname === '/' ? 'nav-active' : ''}`} href="/">
+              Home
+            </Link>
+            <Link className={`nav-item ${pathname === '/blog' ? 'nav-active' : ''}`} href="/blog">Blog</Link>
+            <Link className={`nav-item ${pathname === '/feeds' ? 'nav-active' : ''}`} href="/feeds">Feeds</Link>
+          </div>
+        </nav>      </header>
+      <main className="container mx-auto mt-32 lg:mt-32 px-4 lg:px-64 xl:px-64 mb-4 flex-grow">{children}</main>
+      <footer className="container mx-auto mt-16 px-4 lg:px-64 xl:px-64 py-8">
+        <div className="flex items-center space-x-6">
+
+          <div className="social-icons">            <a href="https://github.com/RobDearling" target="_blank" rel="noopener noreferrer me" title="Github">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                width="20"
+                height="20"
+              >
+                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+              </svg>
+            </a>            <a href="/feeds.xml" target="_blank" rel="noopener noreferrer" title="RSS Feed">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                width="10"
+                height="10"
+              >
+                <path d="M4 11a9 9 0 0 1 9 9"></path>
+                <path d="M4 4a16 16 0 0 1 16 16"></path>
+                <circle cx="5" cy="19" r="1"></circle>
+              </svg>
+            </a>
+          </div>        
+          </div>
+
+      </footer>
     </div>
   );
 }

--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -1,0 +1,61 @@
+import RSS from 'rss';
+import { getSortedPostsData } from './posts';
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+
+function extractDescription(content: string): string {
+  // Remove markdown headers and links, then take first paragraph
+  const cleanContent = content
+    .replace(/^#.*$/gm, '') // Remove headers
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // Convert links to text
+    .replace(/`([^`]+)`/g, '$1') // Remove code backticks
+    .replace(/\n\s*\n/g, '\n') // Remove empty lines
+    .trim();
+  
+  const firstParagraph = cleanContent.split('\n')[0] || '';
+  return firstParagraph.length > 160 
+    ? firstParagraph.substring(0, 157) + '...'
+    : firstParagraph;
+}
+
+export function generateRSSFeed() {
+  const posts = getSortedPostsData();
+  const siteURL = 'https://robdearling.github.io'; // Update this to your actual domain
+  
+  const feed = new RSS({
+    title: 'Rob Dearling\'s Blog',
+    description: 'A blog about technology, development, and other interesting topics',
+    feed_url: `${siteURL}/rss.xml`,
+    site_url: siteURL,
+    image_url: `${siteURL}/favicon.ico`,
+    managingEditor: 'Rob Dearling',
+    webMaster: 'Rob Dearling',
+    copyright: `Copyright ${new Date().getFullYear()}, Rob Dearling`,
+    language: 'en-US',
+    categories: ['Technology', 'Development', 'Programming'],
+    pubDate: new Date().toISOString(),
+    ttl: 1440, // 24 hours
+  });
+
+  posts.forEach((post) => {
+    // Get the full post content to extract description
+    const postsDirectory = path.join(process.cwd(), 'posts');
+    const fullPath = path.join(postsDirectory, `${post.id}.md`);
+    const fileContents = fs.readFileSync(fullPath, 'utf8');
+    const matterResult = matter(fileContents);
+    
+    const description = post.description || extractDescription(matterResult.content);
+    
+    feed.item({
+      title: post.title,
+      description: description,
+      url: `${siteURL}/posts/${post.id}`,
+      guid: `${siteURL}/posts/${post.id}`,
+      date: post.date,
+      author: 'Rob Dearling',
+    });
+  });
+
+  return feed.xml({ indent: true });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,17 @@
         "react-dom": "18.2.0",
         "remark": "^15.0.1",
         "remark-html": "^16.0.1",
-        "remark-prism": "^1.3.6"
+        "remark-prism": "^1.3.6",
+        "rss": "^1.2.2"
       },
       "devDependencies": {
         "@types/node": "^22.9.1",
         "@types/prismjs": "^1.26.5",
         "@types/react": "^18.3.12",
         "@types/remark-prism": "^1.3.7",
+        "@types/rss": "^0.0.32",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
-        "react-snowfall": "^2.2.0",
         "tailwindcss": "^3.4.15",
         "typescript": "^5.6.3"
       },
@@ -1062,6 +1063,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/@types/rss": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/rss/-/rss-0.0.32.tgz",
+      "integrity": "sha512-2oKNqKyUY4RSdvl5eZR1n2Q9yvw3XTe3mQHsFPn9alaNBxfPnbXBtGP8R0SV8pK1PrVnLul0zx7izbm5/gF5Qw==",
+      "dev": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3375,25 +3382,6 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "dev": true
-    },
-    "node_modules/react-snowfall": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-snowfall/-/react-snowfall-2.2.0.tgz",
-      "integrity": "sha512-dRk7vEHq/ZUOG+JHk2k/hH3HmliOWGXr4rKRDeW4mjWuHeI1r5h0Lc1r2jnTtUS1im702d6tCmNGymlNTdhXYg==",
-      "dev": true,
-      "dependencies": {
-        "react-fast-compare": "^3.2.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || 17.x || 18.x",
-        "react-dom": "^16.8 || 17.x || 18.x"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3521,6 +3509,34 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==",
+      "dependencies": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      }
+    },
+    "node_modules/rss/node_modules/mime-db": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+      "integrity": "sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/rss/node_modules/mime-types": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+      "integrity": "sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==",
+      "dependencies": {
+        "mime-db": "~1.25.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/run-parallel": {
@@ -4370,6 +4386,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
     },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "npm run generate-rss && next build",
     "dev": "next dev",
-    "start": "next start"
+    "start": "next start",
+    "generate-rss": "node scripts/generate-rss.js"
   },
   "dependencies": {
     "date-fns": "^4.1.0",
@@ -14,7 +15,8 @@
     "react-dom": "18.2.0",
     "remark": "^15.0.1",
     "remark-html": "^16.0.1",
-    "remark-prism": "^1.3.6"
+    "remark-prism": "^1.3.6",
+    "rss": "^1.2.2"
   },
   "engines": {
     "node": ">=18"
@@ -24,6 +26,7 @@
     "@types/prismjs": "^1.26.5",
     "@types/react": "^18.3.12",
     "@types/remark-prism": "^1.3.7",
+    "@types/rss": "^0.0.32",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",

--- a/pages/api/rss.xml.ts
+++ b/pages/api/rss.xml.ts
@@ -1,0 +1,15 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { generateRSSFeed } from '../../lib/rss';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const rss = generateRSSFeed();
+    
+    res.setHeader('Content-Type', 'application/rss+xml; charset=utf-8');
+    res.setHeader('Cache-Control', 'public, s-maxage=1200, stale-while-revalidate=600');
+    res.status(200).send(rss);
+  } else {
+    res.setHeader('Allow', ['GET']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/blog.tsx
+++ b/pages/blog.tsx
@@ -14,8 +14,6 @@ export async function getStaticProps() {
   };
 }
 
-import { GetStaticProps } from "next";
-
 interface PostData {
   id: string;
   date: string;

--- a/pages/feeds.tsx
+++ b/pages/feeds.tsx
@@ -1,0 +1,175 @@
+import Head from "next/head";
+import Layout, { siteTitle } from "../components/layout";
+import utilStyles from "../styles/utils.module.css";
+import { useState, useEffect } from "react";
+
+interface Feed {
+  title: string;
+  text: string;
+  xmlUrl: string;
+  htmlUrl: string;
+}
+
+interface FeedGroup {
+  title: string;
+  feeds: Feed[];
+}
+
+export default function Feeds() {
+  const [feedData, setFeedData] = useState<{ groups: FeedGroup[]; totalFeeds: number }>({
+    groups: [],
+    totalFeeds: 0
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchFeedData();
+  }, []);
+  const fetchFeedData = async () => {
+    try {
+      const response = await fetch('/feeds.xml');
+      const text = await response.text();
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(text, 'text/xml');
+      
+      const outlines = xmlDoc.querySelectorAll('outline');
+      const allFeeds: Feed[] = [];
+
+      const processOutline = (outline: Element) => {
+        const type = outline.getAttribute('type');
+        const title = outline.getAttribute('title') || outline.getAttribute('text') || '';
+        
+        if (type === 'rss') {
+          const feed: Feed = {
+            title,
+            text: outline.getAttribute('text') || title,
+            xmlUrl: outline.getAttribute('xmlUrl') || '',
+            htmlUrl: outline.getAttribute('htmlUrl') || ''
+          };
+          allFeeds.push(feed);
+        } else if (outline.children.length > 0) {
+          // Process child outlines recursively
+          Array.from(outline.children).forEach(processOutline);
+        }
+      };
+
+      outlines.forEach(processOutline);
+
+      // Sort feeds alphabetically by title
+      allFeeds.sort((a, b) => a.title.localeCompare(b.title));
+
+      setFeedData({ 
+        groups: [{ title: 'RSS Feeds', feeds: allFeeds }], 
+        totalFeeds: allFeeds.length 
+      });
+      setLoading(false);
+    } catch (err) {
+      setError('Failed to load feed data');
+      setLoading(false);
+    }
+  };
+
+  const downloadFeedsXml = () => {
+    const element = document.createElement('a');
+    element.setAttribute('href', '/feeds.xml');
+    element.setAttribute('download', 'feeds.xml');
+    element.style.display = 'none';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+  };
+
+  if (loading) {
+    return (
+      <Layout>
+        <Head>
+          <title>RSS Feeds - {siteTitle}</title>
+        </Head>
+        <div className="flex justify-center items-center min-h-64">
+          <div className="text-lg">Loading feeds...</div>
+        </div>
+      </Layout>
+    );
+  }
+
+  if (error) {
+    return (
+      <Layout>
+        <Head>
+          <title>RSS Feeds - {siteTitle}</title>
+        </Head>
+        <div className="flex justify-center items-center min-h-64">
+          <div className="text-lg text-red-400">{error}</div>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <Head>
+        <title>RSS Feeds - {siteTitle}</title>
+        <meta name="description" content="My RSS feed subscriptions" />
+      </Head>
+      
+      <section className={`${utilStyles.headingMd} ${utilStyles.padding1px}`}>
+        <div className="flex justify-between items-center mb-8">
+          <h2 className="font-bold text-5xl">RSS Feeds</h2>
+          <button
+            onClick={downloadFeedsXml}
+            className="bg-sky-600 hover:bg-sky-700 text-white font-semibold py-2 px-4 rounded-lg transition-colors"
+          >
+            Download OPML
+          </button>
+        </div>
+        
+        <div className="mb-6">
+          <p className="text-gray-300 text-lg">
+            I follow {feedData.totalFeeds} RSS feeds across various topics. 
+            You can download the OPML file to import these feeds into your own RSS reader.
+          </p>
+        </div>        {feedData.groups[0] && (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {feedData.groups[0].feeds.map((feed, feedIndex) => (
+              <div
+                key={feedIndex}
+                className="bg-gray-800 rounded-lg p-4 hover:bg-gray-700 transition-colors"
+              >
+                <div className="mb-2">
+                  <h4 className="font-semibold text-white truncate" title={feed.title}>
+                    {feed.title}
+                  </h4>
+                </div>
+                <div className="flex flex-col space-y-2 text-sm">
+                  {feed.htmlUrl && (
+                    <a
+                      href={feed.htmlUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sky-400 hover:text-sky-300 truncate transition-colors"
+                      title={feed.htmlUrl}
+                    >
+                      🌐 Visit Website
+                    </a>
+                  )}
+                  {feed.xmlUrl && (
+                    <a
+                      href={feed.xmlUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-orange-400 hover:text-orange-300 truncate transition-colors"
+                      title={feed.xmlUrl}
+                    >
+                      📡 RSS Feed
+                    </a>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </Layout>
+  );
+}

--- a/public/feeds.xml
+++ b/public/feeds.xml
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+    <head>
+        <title>Reeder</title>
+    </head>
+    <body>
+        <outline type="rss" xmlUrl="https://aran.dev/posts/index.xml"
+            title="Posts on Aran Wilkinson" text="Posts on Aran Wilkinson"
+            htmlUrl="https://aran.dev/posts/" />
+        <outline type="rss" xmlUrl="https://kevquirk.com/rss/" title="Kev Quirk" text="Kev Quirk"
+            htmlUrl="https://kevquirk.com" />
+        <outline type="rss" xmlUrl="https://www.gbbns.co/rss.xml" title="Chris Gibbons | gbbns.co"
+            text="Chris Gibbons | gbbns.co" htmlUrl="https://www.gbbns.co/" />
+        <outline type="rss" xmlUrl="https://hakaselogs.me/index.xml" title="hakaselogs"
+            text="hakaselogs" htmlUrl="/" />
+        <outline type="rss" xmlUrl="https://cleverlaziness.com/reviews/index.xml"
+            title="Reviews | Clever Laziness" text="Reviews | Clever Laziness"
+            htmlUrl="https://cleverlaziness.com/reviews/" />
+        <outline type="rss" xmlUrl="https://www.seastone.io/rss/" title="Seastone" text="Seastone"
+            htmlUrl="https://www.seastone.io/" />
+        <outline type="rss" xmlUrl="https://stuartmccoll.github.io/index.xml" title="Stuart McColl"
+            text="Stuart McColl" htmlUrl="https://stuartmccoll.github.io/" />
+        <outline type="rss" xmlUrl="https://chris.funderburg.me/index.xml"
+            title="Chris Rants at Clouds" text="Chris Rants at Clouds"
+            htmlUrl="https://chris.funderburg.me/" />
+        <outline type="rss" xmlUrl="https://kevingimbel.de/feed/" title="kevingimbel.de"
+            text="kevingimbel.de" htmlUrl="https://kevingimbel.de/blog" />
+        <outline type="rss" xmlUrl="https://mijndertstuij.nl/feed.xml" title="Mijndert Stuij"
+            text="Mijndert Stuij" htmlUrl="https://mijndertstuij.nl" />
+        <outline type="rss" xmlUrl="https://yadl.info/en/feed.rss" title="yadl.info"
+            text="yadl.info" htmlUrl="https://yadl.info/en" />
+        <outline type="rss" xmlUrl="https://manuelmoreale.com/feed/" title="Manuel Moreale"
+            text="Manuel Moreale" htmlUrl="https://manuelmoreale.com" />
+        <outline type="rss" xmlUrl="https://cloudcauldron.io/index.xml" title="Cloud Cauldron Ltd"
+            text="Cloud Cauldron Ltd" htmlUrl="https://cloudcauldron.io/" />
+        <outline type="rss" xmlUrl="https://charity.wtf/feed/" title="charity.wtf"
+            text="charity.wtf" htmlUrl="https://charity.wtf" />
+        <outline type="rss" xmlUrl="https://muratbuffalo.blogspot.com/feeds/posts/default?alt=rss"
+            title="Murat buffalo" text="Murat buffalo" htmlUrl="https://muratbuffalo.blogspot.com/" />
+        <outline type="rss" xmlUrl="https://jb3.dev/feed.xml" title="Joe Banks's Blog"
+            text="Joe Banks's Blog" htmlUrl="https://jb3.dev/" />
+        <outline type="rss" xmlUrl="https://justingarrison.com/index.xml"
+            title="Justin Garrison's Homepage" text="Justin Garrison's Homepage"
+            htmlUrl="https://justingarrison.com/" />
+        <outline type="rss" xmlUrl="https://chrisshort.net/index.xml" title="Chris Short"
+            text="Chris Short" htmlUrl="https://chrisshort.net/" />
+        <outline type="rss" xmlUrl="https://jvt.me/feed.xml" title="Jamie Tanna | Software Engineer"
+            text="Jamie Tanna | Software Engineer" htmlUrl="https://www.jvt.me/" />
+        <outline type="rss" xmlUrl="https://philipnewborough.co.uk/feed/"
+            title="Blog - Philip Newborough" text="Blog - Philip Newborough"
+            htmlUrl="https://philipnewborough.co.uk/blog" />
+        <outline type="rss" xmlUrl="https://crys.site/index.xml" title="Michal's blog"
+            text="Michal's blog" htmlUrl="https://crys.site" />
+        <outline type="rss" xmlUrl="https://popey.com/feed/" title="Alan Pope's blog"
+            text="Alan Pope's blog" htmlUrl="https://popey.com/blog/" />
+        <outline type="rss" xmlUrl="https://rogs.me/index.xml" title="rogs" text="rogs"
+            htmlUrl="https://rogs.me/" />
+        <outline type="rss" xmlUrl="https://brunty.me/index.xml"
+            title="Hi, I'm Brunty on Matt Brunt - Developer &amp; Problem Solver"
+            text="Hi, I'm Brunty on Matt Brunt - Developer &amp; Problem Solver"
+            htmlUrl="https://brunty.me/" />
+        <outline type="rss" xmlUrl="https://nelson.cloud/index.xml" title="nelson.cloud ☁️"
+            text="nelson.cloud ☁️" htmlUrl="https://nelson.cloud/" />
+        <outline type="rss" xmlUrl="https://grubz.net/feed/" title="gru:Bz" text="gru:Bz"
+            htmlUrl="https://grubz.net/" />
+        <outline type="rss" xmlUrl="https://rknight.me/subscribe/posts/atom.xml"
+            title="Robb Knight • Posts • Atom Feed" text="Robb Knight • Posts • Atom Feed"
+            htmlUrl="https://rknight.me" />
+        <outline type="rss" xmlUrl="https://lazybea.rs/index.xml" title="Lazybear" text="Lazybear"
+            htmlUrl="http://lazybea.rs/" />
+        <outline type="rss" xmlUrl="https://axxuy.xyz/feed.xml" title="Axxuy" text="Axxuy"
+            htmlUrl="https://axxuy.xyz/blog" />
+        <outline type="rss" xmlUrl="https://alvin.codes/rss.xml" title="Alvin Bryan"
+            text="Alvin Bryan" htmlUrl="https://alvin.codes/" />
+        <outline type="rss" xmlUrl="https://ncase.me/feed.xml" title="Nicky's New Shtuff"
+            text="Nicky's New Shtuff" htmlUrl="https://ncase.me/" />
+        <outline type="rss" xmlUrl="https://explaining.software/rss.xml"
+            title="Explaining Software Design" text="Explaining Software Design"
+            htmlUrl="https://explaining.software/" />
+        <outline type="rss"
+            xmlUrl="https://explaining.software/archive/senior-developer-agents/rss/"
+            title="Explaining Software Design" text="Explaining Software Design"
+            htmlUrl="https://explaining.software/" />
+        <outline type="rss" xmlUrl="https://82mhz.net/index.xml" title="82MHz - All blog posts"
+            text="82MHz - All blog posts" htmlUrl="http://82mhz.net/posts/" />
+        <outline type="rss" xmlUrl="https://mirawelner.com/rss.xml" title="Mira Welner's Tech Blog!"
+            text="Mira Welner's Tech Blog!" htmlUrl="https://mirawelner.com" />
+        <outline type="rss" xmlUrl="https://blog.ctms.me/index.xml" title="Dom Corriveau"
+            text="Dom Corriveau" htmlUrl="https://blog.ctms.me/" />
+        <outline type="rss" xmlUrl="https://www.netmeister.org/blog/rss.xml"
+            title="Signs of Triviality" text="Signs of Triviality"
+            htmlUrl="http://www.netmeister.org/blog/" />
+        <outline type="rss" xmlUrl="https://www.fromjason.xyz/p/notebook/feed/feed.xml"
+            title="notebook from jason" text="notebook from jason"
+            htmlUrl="https://www.fromjason.xyz" />
+        <outline type="rss" xmlUrl="https://bell.bz/feed/" title="Andy Bell" text="Andy Bell"
+            htmlUrl="https://bell.bz" />
+        <outline type="rss" xmlUrl="https://minutestomidnight.co.uk/feed.xml"
+            title="Minutes to Midnight" text="Minutes to Midnight"
+            htmlUrl="https://minutestomidnight.co.uk" />
+        <outline type="rss" xmlUrl="https://rldane.space/feeds/all.atom.xml" title="R.L. Dane"
+            text="R.L. Dane" htmlUrl="https://rldane.space/" />
+        <outline type="rss" xmlUrl="https://mertbulan.com/feed.xml" title="Mert Bulan"
+            text="Mert Bulan" htmlUrl="https://mertbulan.com/" />
+        <outline type="rss" xmlUrl="https://blog.alexellis.io/feed/" title="Alex Ellis' Blog"
+            text="Alex Ellis' Blog" htmlUrl="https://blog.alexellis.io/" />
+        <outline type="rss" xmlUrl="https://blog.howardjohn.info/index.xml"
+            title="howardjohn's blog" text="howardjohn's blog"
+            htmlUrl="https://blog.howardjohn.info/" />
+        <outline type="rss" xmlUrl="https://www.romaglushko.com/rss.xml" title="Roma Glushko's Blog"
+            text="Roma Glushko's Blog" htmlUrl="https://www.romaglushko.com/" />
+        <outline type="rss" xmlUrl="https://blog.brakmic.com/feed/" title="Coding" text="Coding"
+            htmlUrl="https://blog.brakmic.com" />
+        <outline type="rss" xmlUrl="http://rednafi.com/index.xml" title="Redowan's Reflections"
+            text="Redowan's Reflections" htmlUrl="http://rednafi.com/" />
+        <outline type="rss" xmlUrl="https://serce.me/feed.xml" title="SerCe's blog"
+            text="SerCe's blog" htmlUrl="https://serce.me" />
+        <outline type="rss" xmlUrl="https://marcjenkins.co.uk/feed/" title="Marc Jenkins"
+            text="Marc Jenkins" htmlUrl="https://marcjenkins.co.uk" />
+        <outline type="rss" xmlUrl="https://brandons-journal.com/feed/" title="Brandon's Journal"
+            text="Brandon's Journal" htmlUrl="https://brandons-journal.com/" />
+        <outline type="rss" xmlUrl="https://gil.codes/feeds/all.atom.xml"
+            title="Gil's blog about code, technology, and leadership"
+            text="Gil's blog about code, technology, and leadership" htmlUrl="https://gil.codes/" />
+        <outline type="rss" xmlUrl="https://oneforthecode.com/index.xml" title="One For The Code"
+            text="One For The Code" htmlUrl="http://oneforthecode.com/" />
+        <outline type="rss" xmlUrl="https://beccais.online/rss/" title="Rebecca Owen"
+            text="Rebecca Owen" htmlUrl="https://beccais.online/" />
+        <outline type="rss" xmlUrl="https://chrispbarber.com/feed/" title="Chris Barber"
+            text="Chris Barber" htmlUrl="https://chrispbarber.com/" />
+        <outline type="rss" xmlUrl="https://johnlarge.co.uk/feed/"
+            title="John Large – Technology, Hardware,Web Development, Digital Privacy &amp; Ethics"
+            text="John Large – Technology, Hardware,Web Development, Digital Privacy &amp; Ethics"
+            htmlUrl="https://www.johnlarge.co.uk/" />
+        <outline type="rss" xmlUrl="https://cra.mr/rss.xml" title="Cra.mr" text="Cra.mr"
+            htmlUrl="https://cra.mr/" />
+        <outline type="rss" xmlUrl="https://code.mendhak.com/feed.xml" title="Mendhak / Code"
+            text="Mendhak / Code" htmlUrl="https://code.mendhak.com" />
+        <outline type="rss" xmlUrl="https://crowdersoup.com/index.xml" title="Home on CrowderSoup"
+            text="Home on CrowderSoup" htmlUrl="/" />
+        <outline type="rss" xmlUrl="https://aleksandrhovhannisyan.com/feed.xml"
+            title="Aleksandr Hovhannisyan" text="Aleksandr Hovhannisyan"
+            htmlUrl="https://www.aleksandrhovhannisyan.com" />
+        <outline type="rss" xmlUrl="https://blog.rubenwardy.com/feed/" title="rubenwardy's blog"
+            text="rubenwardy's blog" htmlUrl="https://blog.rubenwardy.com" />
+        <outline type="rss" xmlUrl="https://hackeryarn.com/index.xml" title="hackeryarn"
+            text="hackeryarn" htmlUrl="https://hackeryarn.com/" />
+        <outline type="rss" xmlUrl="https://chrismcleod.dev/feed/"
+            title="Chris McLeod's blog — Blog Posts — Atom Feed"
+            text="Chris McLeod's blog — Blog Posts — Atom Feed" htmlUrl="https://chrismcleod.dev" />
+        <outline type="rss" xmlUrl="https://claytonerrington.com/feed.xml" title="Clayton Errington"
+            text="Clayton Errington" htmlUrl="https://claytonerrington.com" />
+        <outline type="rss" xmlUrl="https://coryd.dev/feeds/links.xml"
+            title="Links feed • Cory Dransfeldt" text="Links feed • Cory Dransfeldt"
+            htmlUrl="https://www.coryd.dev/feeds/links.xml" />
+        <outline type="rss" xmlUrl="https://coryd.dev/feeds/all.xml"
+            title="All activity feed • Cory Dransfeldt" text="All activity feed • Cory Dransfeldt"
+            htmlUrl="https://www.coryd.dev/feeds/all.xml" />
+        <outline type="rss" xmlUrl="https://cyberdemon.org/feed.xml"
+            title="Cyberdemon.org is a cool domain" text="Cyberdemon.org is a cool domain"
+            htmlUrl="https://www.cyberdemon.org/" />
+        <outline type="rss" xmlUrl="https://chromamine.com/feeds/posts.xml" title="Harris Lapiroff"
+            text="Harris Lapiroff" htmlUrl="https://chromamine.com" />
+        <outline type="rss" xmlUrl="https://dedoimedo.com/rss_feed.xml" title="Dedoimedo RSS"
+            text="Dedoimedo RSS" htmlUrl="https://www.dedoimedo.com" />
+        <outline type="rss" xmlUrl="https://pdx.su/feed.xml" title="Jeff Sandberg's Blog"
+            text="Jeff Sandberg's Blog" htmlUrl="https://pdx.su" />
+        <outline type="rss" xmlUrl="https://jesseduffield.com/feed.xml" title="Pursuit Of Laziness"
+            text="Pursuit Of Laziness" htmlUrl="https://jesseduffield.com/" />
+        <outline type="rss" xmlUrl="https://blog.jonlu.ca/feed.xml" title="JonLuca's Blog"
+            text="JonLuca's Blog" htmlUrl="https://blog.jonlu.ca" />
+        <outline type="rss" xmlUrl="https://josem.co//articles/index.xml"
+            title="Articles on Jose M." text="Articles on Jose M."
+            htmlUrl="https://josem.co/articles/" />
+        <outline type="rss" xmlUrl="https://kevincox.ca/feed.atom" title="Kevin Cox's Blog"
+            text="Kevin Cox's Blog" htmlUrl="https://kevincox.ca/" />
+        <outline type="rss" xmlUrl="https://blog.liw.fi/englishfeed/index.rss" title="englishfeed"
+            text="englishfeed" htmlUrl="https://blog.liw.fi/englishfeed/" />
+        <outline type="rss" xmlUrl="https://www.lkhrs.com/index.xml"
+            title="Everything on Luke's Wild Website" text="Everything on Luke's Wild Website"
+            htmlUrl="https://www.lkhrs.com/" />
+        <outline type="rss" xmlUrl="https://michaelharley.net/feed/feed.xml" title="Michael Harley"
+            text="Michael Harley" htmlUrl="https://michaelharley.net" />
+        <outline type="rss" xmlUrl="https://navendu.me/index.xml"
+            title="Navendu Pottekkat - The Open Source Absolutist"
+            text="Navendu Pottekkat - The Open Source Absolutist" htmlUrl="https://navendu.me/" />
+        <outline type="rss" xmlUrl="https://scottwillsey.com/rss.xml" title="ScottWillsey"
+            text="ScottWillsey" htmlUrl="https://scottwillsey.com/" />
+        <outline type="rss" xmlUrl="https://shubhamjain.co/rss.xml" title="Shubham Jain's Blog"
+            text="Shubham Jain's Blog" htmlUrl="https://shubhamjain.co/" />
+        <outline type="rss" xmlUrl="https://dataswamp.org/~solene/rss.xml" title="Solene'%"
+            text="Solene'%" htmlUrl="https://dataswamp.org/~solene/" />
+        <outline type="rss" xmlUrl="https://yieldcode.blog/rss/feed.xml" title="yield code();"
+            text="yield code();" htmlUrl="https://yieldcode.blog/" />
+        <outline type="rss" xmlUrl="https://www.micah.soy/index.xml" title="Micah Henning"
+            text="Micah Henning" htmlUrl="https://www.micah.soy/" />
+        <outline type="rss" xmlUrl="https://davi.sh/rss.xml" title="Davis Haupt's Blog"
+            text="Davis Haupt's Blog" htmlUrl="https://davi.sh/blog/" />
+        <outline type="rss" xmlUrl="https://muxup.com/feed.xml" title="Muxup" text="Muxup"
+            htmlUrl="https://muxup.com" />
+        <outline type="rss" xmlUrl="https://localghost.dev/articles.xml"
+            title="localghost.dev - all articles" text="localghost.dev - all articles"
+            htmlUrl="https://localghost.dev" />
+        <outline type="rss" xmlUrl="https://localghost.dev/feed.xml" title="localghost"
+            text="localghost" htmlUrl="https://localghost.dev" />
+        <outline type="rss" xmlUrl="https://johnnyreilly.com/rss.xml" title="I CAN MAKE THIS WORK"
+            text="I CAN MAKE THIS WORK" htmlUrl="https://johnnyreilly.com/" />
+        <outline type="rss" xmlUrl="https://danielpecos.com/index.xml"
+            title="GeekWare - Daniel Pecos Martínez" text="GeekWare - Daniel Pecos Martínez"
+            htmlUrl="https://danielpecos.com/" />
+        <outline type="rss" xmlUrl="https://lia.mg/feed.xml" title="liamg" text="liamg"
+            htmlUrl="https://lia.mg/" />
+        <outline type="rss" xmlUrl="https://www.seangoedecke.com/rss.xml"
+            title="seangoedecke.com RSS feed" text="seangoedecke.com RSS feed"
+            htmlUrl="https://seangoedecke.com" />
+        <outline type="rss" xmlUrl="https://ashnik.com/feed/" title="Ashnik" text="Ashnik"
+            htmlUrl="https://www.ashnik.com" />
+        <outline type="rss" xmlUrl="https://thedorkweb.bearblog.dev/feed/"
+            title="Notes From The Dork Web" text="Notes From The Dork Web"
+            htmlUrl="https://thedorkweb.bearblog.dev/" />
+        <outline type="rss" xmlUrl="https://www.schneier.com/feed/" title="Schneier on Security"
+            text="Schneier on Security" htmlUrl="https://www.schneier.com/" />
+        <outline type="rss" xmlUrl="https://edwardsnowden.substack.com/feed"
+            title="Continuing Ed⁠ — with Edward Snowden" text="Continuing Ed⁠ — with Edward Snowden"
+            htmlUrl="https://edwardsnowden.substack.com" />
+        <outline type="rss" xmlUrl="https://ryanholiday.net/feed/atom/" title="RyanHoliday.net"
+            text="RyanHoliday.net" htmlUrl="https://ryanholiday.net/" />
+        <outline type="rss" xmlUrl="https://martinheinz.dev/rss/" title="Martin Heinz's Blog"
+            text="Martin Heinz's Blog" htmlUrl="https://martinheinz.dev/rss" />
+        <outline type="rss" xmlUrl="https://miek.nl/index.xml" title="Miek Gieben"
+            text="Miek Gieben" htmlUrl="https://miek.nl/" />
+        <outline type="rss" xmlUrl="https://paulphilippov.com/articles.rss" title="Paul Philippov"
+            text="Paul Philippov" htmlUrl="https://paulphilippov.com/articles" />
+        <outline type="rss" xmlUrl="https://jlelse.blog/.rss" title="Jan-Lukas Else"
+            text="Jan-Lukas Else" htmlUrl="https://jlelse.blog" />
+        <outline type="rss" xmlUrl="https://desmondrivet.com/feeds/all.rss" title="Desmond Rivet"
+            text="Desmond Rivet" htmlUrl="https://desmondrivet.com" />
+        <outline type="rss" xmlUrl="https://blog.thenewoil.org/feed/" title="The New Oil"
+            text="The New Oil" htmlUrl="https://blog.thenewoil.org/" />
+        <outline type="rss" xmlUrl="https://thomasthornton.cloud/feed/"
+            title="Thomas Thornton Azure Blog" text="Thomas Thornton Azure Blog"
+            htmlUrl="https://thomasthornton.cloud" />
+        <outline type="rss" xmlUrl="https://blog.diego.dev/index.xml" title="Diego Siqueira"
+            text="Diego Siqueira" htmlUrl="https://blog.diego.dev/" />
+        <outline type="rss" xmlUrl="https://blog.erikhorton.com/index.xml" title="Erik Horton"
+            text="Erik Horton" htmlUrl="https://blog.erikhorton.com/" />
+        <outline type="rss" xmlUrl="https://iximiuz.com/feed.rss"
+            title="Ivan on Containers, Kubernetes, and Server-Side"
+            text="Ivan on Containers, Kubernetes, and Server-Side" htmlUrl="https://iximiuz.com/" />
+        <outline type="rss" xmlUrl="https://blog.mbrt.dev/index.xml" title="mbrt blog"
+            text="mbrt blog" htmlUrl="https://blog.mbrt.dev/" />
+        <outline type="rss" xmlUrl="https://blog.setale.me/index.xml" title="Lorenzo Setale's Blog"
+            text="Lorenzo Setale's Blog" htmlUrl="https://blog.setale.me/" />
+        <outline type="rss" xmlUrl="https://davidwinter.dev/index.xml" title="david winter"
+            text="david winter" htmlUrl="https://davidwinter.dev/" />
+        <outline type="rss" xmlUrl="https://dylanjuran.me/atom.xml" title="Dylan Juran"
+            text="Dylan Juran" htmlUrl="https://dylanjuran.me/" />
+        <outline type="rss" xmlUrl="https://www.kalzumeus.com/feed/" title="Kalzumeus Software"
+            text="Kalzumeus Software" htmlUrl="https://www.kalzumeus.com" />
+        <outline type="rss" xmlUrl="https://antirez.com/rss" htmlUrl="http://antirez.com" />
+        <outline type="rss" xmlUrl="https://tonsky.me/atom.xml" title="tonsky.me" text="tonsky.me"
+            htmlUrl="https://tonsky.me/" />
+        <outline type="rss" xmlUrl="https://mtlynch.io/index.xml" title="mtlynch.io"
+            text="mtlynch.io" htmlUrl="https://mtlynch.io/" />
+        <outline type="rss" xmlUrl="https://zachholman.com/atom.xml" title="Zach Holman"
+            text="Zach Holman" htmlUrl="https://zachholman.com" />
+        <outline type="rss" xmlUrl="https://blog.container-solutions.com/rss.xml"
+            title="Blog - Container Solutions" text="Blog - Container Solutions"
+            htmlUrl="https://blog.container-solutions.com" />
+        <outline type="rss" xmlUrl="https://michal.sapka.pl/rss.xml" title="Michal's blog"
+            text="Michal's blog" htmlUrl="https://michal.sapka.pl" />
+        <outline type="rss" xmlUrl="https://jerf.org/iri/rss.xml" title="iRi" text="iRi"
+            htmlUrl="https://jerf.org/iri/" />
+        <outline type="rss" xmlUrl="https://pivot-to-ai.com/feed/" title="Pivot to AI"
+            text="Pivot to AI" htmlUrl="https://pivot-to-ai.com" />
+        <outline type="rss" xmlUrl="https://dcurt.is/feed/" title="Dustin Curtis"
+            text="Dustin Curtis" htmlUrl="https://dcurt.is" />
+        <outline title="Independent Personal Blogs - The Great Work"
+            text="Independent Personal Blogs - The Great Work">
+            <outline type="rss" xmlUrl="https://hamatti.org/feed/feed.xml"
+                title="Juha-Matti Santala - Community Builder. Dreamer. Adventurer."
+                text="Juha-Matti Santala - Community Builder. Dreamer. Adventurer."
+                htmlUrl="https://hamatti.org" />
+            <outline type="rss" xmlUrl="https://cassidoo.co/rss.xml" title="Cassidy Williams"
+                text="Cassidy Williams" htmlUrl="https://cassidoo.co/" />
+            <outline type="rss" xmlUrl="https://analogoffice.net/feed.xml" title="Analog Office"
+                text="Analog Office" htmlUrl="https://analogoffice.net/" />
+            <outline type="rss" xmlUrl="https://shellsharks.com/feeds/feed.xml"
+                title="shellsharks Posts" text="shellsharks Posts" htmlUrl="https://shellsharks.com" />
+            <outline type="rss" xmlUrl="https://aegir.org/words/feed" title="Aegir.org"
+                text="Aegir.org" htmlUrl="https://aegir.org" />
+            <outline type="rss" xmlUrl="https://lucvandonkersgoed.com/feed/"
+                title="Luc van Donkersgoed's Notes" text="Luc van Donkersgoed's Notes"
+                htmlUrl="https://lucvandonkersgoed.com" />
+            <outline type="rss" xmlUrl="https://danmall.com/feed.xml"
+                title="Dan Mall Teaches Design Systems, Design Process, and Design Leadership"
+                text="Dan Mall Teaches Design Systems, Design Process, and Design Leadership"
+                htmlUrl="https://danmall.com/" />
+            <outline type="rss" xmlUrl="https://notes.jeddacp.com/feed/" title="Notes by JCProbably"
+                text="Notes by JCProbably" htmlUrl="https://notes.jeddacp.com/" />
+            <outline type="rss" xmlUrl="https://gregorlove.com/articles.atom" title="gRegorLove.com"
+                text="gRegorLove.com" htmlUrl="https://gregorlove.com" />
+            <outline type="rss" xmlUrl="https://adityatelange.in/index.xml" title="Aditya Telange"
+                text="Aditya Telange" htmlUrl="https://adityatelange.in/" />
+            <outline type="rss" xmlUrl="https://alexwlchan.net/atom.xml" title="alexwlchan"
+                text="alexwlchan" htmlUrl="https://alexwlchan.net/" />
+            <outline type="rss" xmlUrl="https://thomasrigby.com/feed.xml" title="Thomas Rigby"
+                text="Thomas Rigby" htmlUrl="https://thomasrigby.com" />
+            <outline type="rss" xmlUrl="https://a.wholelottanothing.org/feed/"
+                title="A Whole Lotta Nothing" text="A Whole Lotta Nothing"
+                htmlUrl="https://a.wholelottanothing.org/" />
+            <outline type="rss" xmlUrl="https://marvin.beckers.dev/blog/index.xml"
+                title="Blog on Marvin Beckers" text="Blog on Marvin Beckers"
+                htmlUrl="https://marvin.beckers.dev/blog/" />
+            <outline type="rss" xmlUrl="https://rachsmith.com/feed.xml"
+                title="Rach Smith's digital garden" text="Rach Smith's digital garden"
+                htmlUrl="https://rachsmith.com/" />
+            <outline type="rss" xmlUrl="https://computer.rip/rss.xml" title="computers are bad"
+                text="computers are bad" htmlUrl="https://computer.rip" />
+            <outline type="rss" xmlUrl="https://stfn.pl/rss.xml" title="STFN" text="STFN"
+                htmlUrl="https://stfn.pl/" />
+            <outline type="rss" xmlUrl="https://chelseatroy.com/feed/" title="Chelsea Troy"
+                text="Chelsea Troy" htmlUrl="https://chelseatroy.com" />
+            <outline type="rss" xmlUrl="https://werd.io/?_t=rss" title="Werd I/O" text="Werd I/O"
+                htmlUrl="https://werd.io/" />
+            <outline type="rss" xmlUrl="https://ntietz.com/atom.xml"
+                title="ntietz.com blog - technically a blog"
+                text="ntietz.com blog - technically a blog" htmlUrl="/blog/" />
+            <outline type="rss" xmlUrl="https://pluralistic.net/feed/"
+                title="Pluralistic: Daily links from Cory Doctorow"
+                text="Pluralistic: Daily links from Cory Doctorow" htmlUrl="https://pluralistic.net" />
+            <outline type="rss" xmlUrl="https://neilzone.co.uk/index.xml" title="Neil's blog"
+                text="Neil's blog" htmlUrl="https://neilzone.co.uk/" />
+            <outline type="rss" xmlUrl="https://fev.al/feed.xml" title="Charles Féval"
+                text="Charles Féval" htmlUrl="https://fev.al" />
+            <outline type="rss" xmlUrl="https://matduggan.com/rss/" title="matduggan.com"
+                text="matduggan.com" htmlUrl="https://matduggan.com/" />
+            <outline type="rss" xmlUrl="https://waxy.org/feed/" title="Waxy.org" text="Waxy.org"
+                htmlUrl="https://waxy.org/" />
+            <outline type="rss" xmlUrl="https://jan.wildeboer.net/feed.xml"
+                title="Jan Wildeboer’s Blog" text="Jan Wildeboer’s Blog"
+                htmlUrl="https://jan.wildeboer.net/" />
+            <outline type="rss" xmlUrl="https://arun.is/rss.xml" title="arun.is" text="arun.is"
+                htmlUrl="https://arun.is/" />
+            <outline type="rss" xmlUrl="https://jvns.ca/atom.xml" title="Julia Evans"
+                text="Julia Evans" htmlUrl="https://jvns.ca" />
+            <outline type="rss" xmlUrl="https://rubenerd.com/feed/" title="Rubenerd" text="Rubenerd"
+                htmlUrl="https://rubenerd.com/" />
+            <outline type="rss" xmlUrl="https://www.simplermachines.com/rss/"
+                title="Simpler Machines" text="Simpler Machines"
+                htmlUrl="https://www.simplermachines.com/" />
+            <outline type="rss" xmlUrl="https://stephango.com/feed.xml" title="Steph Ango"
+                text="Steph Ango" htmlUrl="https://stephango.com" />
+            <outline type="rss" xmlUrl="https://librarianshipwreck.wordpress.com/feed/"
+                title="LibrarianShipwreck" text="LibrarianShipwreck"
+                htmlUrl="https://librarianshipwreck.wordpress.com" />
+            <outline type="rss" xmlUrl="https://micro.webology.dev/feed.xml"
+                title="Jeff Triplett's Micro.blog" text="Jeff Triplett's Micro.blog"
+                htmlUrl="https://micro.webology.dev/" />
+            <outline type="rss" xmlUrl="https://ersei.net/en/blog.atom" title="Ersei 'n Stuff"
+                text="Ersei 'n Stuff" htmlUrl="https://ersei.net" />
+            <outline type="rss" xmlUrl="https://www.drcathicks.com/blog-feed.xml" title="drcathicks"
+                text="drcathicks" htmlUrl="https://www.drcathicks.com/blog" />
+            <outline type="rss" xmlUrl="https://tantek.com/updates.atom" title="Tantek Çelik"
+                text="Tantek Çelik" htmlUrl="https://tantek.com/" />
+            <outline type="rss" xmlUrl="https://walknotes.com/feed/" title="Walknotes"
+                text="Walknotes" htmlUrl="https://walknotes.com" />
+            <outline type="rss" xmlUrl="https://www.basicappleguy.com/basicappleblog?format=rss"
+                title="Basic Apple Guy | Apple Wallpapers, Reviews, and Merch"
+                text="Basic Apple Guy | Apple Wallpapers, Reviews, and Merch"
+                htmlUrl="https://basicappleguy.com/" />
+        </outline>
+    </body>
+</opml>

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+        <title><![CDATA[Rob Dearling's Blog]]></title>
+        <description><![CDATA[A blog about technology, development, and other interesting topics]]></description>
+        <link>https://robdearling.github.io</link>
+        <image>
+            <url>https://robdearling.github.io/favicon.ico</url>
+            <title>Rob Dearling&apos;s Blog</title>
+            <link>https://robdearling.github.io</link>
+        </image>
+        <generator>RSS for Node</generator>
+        <lastBuildDate>Tue, 27 May 2025 11:00:37 GMT</lastBuildDate>
+        <atom:link href="https://robdearling.github.io/rss.xml" rel="self" type="application/rss+xml"/>
+        <pubDate>Tue, 27 May 2025 11:00:37 GMT</pubDate>
+        <copyright><![CDATA[Copyright 2025, Rob Dearling]]></copyright>
+        <language><![CDATA[en-US]]></language>
+        <managingEditor><![CDATA[Rob Dearling]]></managingEditor>
+        <webMaster><![CDATA[Rob Dearling]]></webMaster>
+        <ttl>1440</ttl>
+        <category><![CDATA[Technology]]></category>
+        <category><![CDATA[Development]]></category>
+        <category><![CDATA[Programming]]></category>
+        <item>
+            <title><![CDATA[Using Cloudflare R2 as a Terraform backend]]></title>
+            <description><![CDATA[When creating this website, I decided to work with a tech stack that I'm not familiar with(Within certain boundaries). Typically, while working with Terrafor...]]></description>
+            <link>https://robdearling.github.io/posts/using-r2-for-tf-state</link>
+            <guid isPermaLink="false">https://robdearling.github.io/posts/using-r2-for-tf-state</guid>
+            <dc:creator><![CDATA[Rob Dearling]]></dc:creator>
+            <pubDate>Mon, 09 Dec 2024 00:00:00 GMT</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[Building a site with technology I dont use]]></title>
+            <description><![CDATA[When building this site I decided I was going to use it as a way to learn and play with technology that I typically wouldn't use within my daily work tech st...]]></description>
+            <link>https://robdearling.github.io/posts/building-a-site-with-technology-i-dont-use</link>
+            <guid isPermaLink="false">https://robdearling.github.io/posts/building-a-site-with-technology-i-dont-use</guid>
+            <dc:creator><![CDATA[Rob Dearling]]></dc:creator>
+            <pubDate>Sun, 08 Dec 2024 00:00:00 GMT</pubDate>
+        </item>
+    </channel>
+</rss>

--- a/scripts/generate-rss.js
+++ b/scripts/generate-rss.js
@@ -1,0 +1,98 @@
+const fs = require('fs');
+const path = require('path');
+const RSS = require('rss');
+const matter = require('gray-matter');
+
+const postsDirectory = path.join(process.cwd(), 'posts');
+
+function getSortedPostsData() {
+  const fileNames = fs.readdirSync(postsDirectory);
+  const allPostsData = fileNames.map((fileName) => {
+    const id = fileName.replace(/\.md$/, '');
+    const fullPath = path.join(postsDirectory, fileName);
+    const fileContents = fs.readFileSync(fullPath, 'utf8');
+
+    const matterResult = matter(fileContents);
+    return {
+      id,
+      date: matterResult.data.date,
+      ...matterResult.data,
+    };
+  });
+  return allPostsData.sort((a, b) => {
+    if (a.date < b.date) {
+      return 1;
+    } else {
+      return -1;
+    }
+  });
+}
+
+function extractDescription(content) {
+  // Remove markdown headers and links, then take first paragraph
+  const cleanContent = content
+    .replace(/^#.*$/gm, '') // Remove headers
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // Convert links to text
+    .replace(/`([^`]+)`/g, '$1') // Remove code backticks
+    .replace(/\n\s*\n/g, '\n') // Remove empty lines
+    .trim();
+  
+  const firstParagraph = cleanContent.split('\n')[0] || '';
+  return firstParagraph.length > 160 
+    ? firstParagraph.substring(0, 157) + '...'
+    : firstParagraph;
+}
+
+function generateRSSFeed() {
+  const posts = getSortedPostsData();
+  const siteURL = 'https://robdearling.github.io'; // Update this to your actual domain
+  
+  const feed = new RSS({
+    title: 'Rob Dearling\'s Blog',
+    description: 'A blog about technology, development, and other interesting topics',
+    feed_url: `${siteURL}/rss.xml`,
+    site_url: siteURL,
+    image_url: `${siteURL}/favicon.ico`,
+    managingEditor: 'Rob Dearling',
+    webMaster: 'Rob Dearling',
+    copyright: `Copyright ${new Date().getFullYear()}, Rob Dearling`,
+    language: 'en-US',
+    categories: ['Technology', 'Development', 'Programming'],
+    pubDate: new Date().toISOString(),
+    ttl: 1440, // 24 hours
+  });
+
+  posts.forEach((post) => {
+    // Get the full post content to extract description
+    const fullPath = path.join(postsDirectory, `${post.id}.md`);
+    const fileContents = fs.readFileSync(fullPath, 'utf8');
+    const matterResult = matter(fileContents);
+    
+    const description = post.description || extractDescription(matterResult.content);
+    
+    feed.item({
+      title: post.title,
+      description: description,
+      url: `${siteURL}/posts/${post.id}`,
+      guid: `${siteURL}/posts/${post.id}`,
+      date: post.date,
+      author: 'Rob Dearling',
+    });
+  });
+
+  return feed.xml({ indent: true });
+}
+
+function generateStaticRSS() {
+  const rss = generateRSSFeed();
+  const publicDir = path.join(process.cwd(), 'public');
+  
+  if (!fs.existsSync(publicDir)) {
+    fs.mkdirSync(publicDir, { recursive: true });
+  }
+  
+  fs.writeFileSync(path.join(publicDir, 'rss.xml'), rss);
+  console.log('RSS feed generated successfully at public/rss.xml');
+}
+
+generateStaticRSS();


### PR DESCRIPTION
- Implemented an API route for generating RSS feeds at `/api/rss.xml`.
- Created a new page for displaying RSS feeds with a download option for OPML format.
- Added a static OPML file containing various RSS feeds to the public directory.
- Developed a script to generate the RSS feed dynamically from markdown posts.
- Updated the public RSS feed with relevant metadata and recent posts.
